### PR TITLE
Rewrite technology/idea help formspecs not to use doc pages

### DIFF
--- a/mods/ctw_resources/ideas.lua
+++ b/mods/ctw_resources/ideas.lua
@@ -89,7 +89,7 @@ function ctw_resources.show_idea_form(pname, id)
 		text = is_visible and idea.description,
 		labeltext = "This idea is not yet discovered by your team.",
 		
-	})
+	}, pname)
 	-- show it
 	minetest.show_formspec(pname, "ctw_resources:idea_"..id, form)
 	return true
@@ -108,16 +108,27 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		for field,_ in pairs(fields) do
 			local tech_id = string.match(field, "^goto_tech_(.+)$");
 			if tech_id and ctw_technologies._get_technologies()[tech_id] then
+				ctw_technologies.form_returnstack_push(pname, function(pname) ctw_resources.show_idea_form(pname, id) end)
 				ctw_technologies.show_technology_form(pname, tech_id)
 				return
 			end
 			
 			local ref_id = string.match(field, "^goto_ref_(.+)$");
 			if ref_id then
+				ctw_technologies.form_returnstack_push(pname, function(pname) ctw_resources.show_idea_form(pname, id) end)
 				ctw_resources.show_reference_form(pname, ref_id)
 				return
 			end
 		end
+		
+		if fields.goto_back then
+			ctw_technologies.form_returnstack_pop(pname)
+		end
+		
+		if fields.quit then
+			ctw_technologies.form_returnstack_clear(pname)
+		end
+		
 	end
 
 end)

--- a/mods/ctw_resources/ideas.lua
+++ b/mods/ctw_resources/ideas.lua
@@ -26,58 +26,105 @@ local function logs(str)
 	minetest.log("action", "[ctw_resources] "..str)
 end
 
-local function idea_form_builder(id)
+-- Formspec information
+FORM = {}
+-- Width of formspec
+FORM.WIDTH = 15
+FORM.HEIGHT = 10.5
+
+--[[ Recommended bounding box coordinates for widgets to be placed in entry pages. Make sure
+all entry widgets are completely inside these coordinates to avoid overlapping. ]]
+FORM.ENTRY_START_X = 1
+FORM.ENTRY_START_Y = 0.5
+FORM.ENTRY_END_X = FORM.WIDTH
+FORM.ENTRY_END_Y = FORM.HEIGHT - 0.5
+FORM.ENTRY_WIDTH = FORM.ENTRY_END_X - FORM.ENTRY_START_X
+FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
+
+function ctw_resources.show_idea_form(pname, id)
 	local idea = ideas[id]
 	if not idea then
-		error("idea_form_builder: ID "..id.." is unknown!")
+		return true
+	end
+	
+	local team = teams.get_by_player(pname)
+	local is_visible = false
+	if team then
+		local istate = ctw_resources.get_team_idea_state(id, team)
+		if istate.state~="undiscovered" then
+			if istate.state=="discovered" then
+				is_visible = istate.by == pname
+			else
+				is_visible = true
+			end
+		end
 	end
 
 	local n_tech_lines = math.max(math.max(#idea.references_required, #idea.technologies_required),
 			#idea.technologies_gained)
 
 	local tech_line_h = 1
-	local desc_height = doc.FORMSPEC.ENTRY_HEIGHT - tech_line_h*n_tech_lines - 0.5
-	local tech_start_y = doc.FORMSPEC.ENTRY_START_Y + desc_height
-	local third_width = doc.FORMSPEC.ENTRY_WIDTH / 3
+	local desc_height = FORM.ENTRY_HEIGHT - tech_line_h*n_tech_lines - 0.5
+	local tech_start_y = FORM.ENTRY_START_Y + desc_height
+	local third_width = FORM.ENTRY_WIDTH / 3
 
-	local form = "label["
-					..doc.FORMSPEC.ENTRY_START_X..","..doc.FORMSPEC.ENTRY_START_Y
+	local form = "size["..FORM.WIDTH..","..FORM.HEIGHT.."]real_coordinates[]"
+	
+	form = form .. "vertlabel[0.15,0.5"
+					..";I D E A]";
+	form = form .. "box[0,0;0.5,"..FORM.HEIGHT..";#00FF00]";
+	
+
+	form = form .. "label["
+					..FORM.ENTRY_START_X..","..FORM.ENTRY_START_Y
 					..";"..idea.name.."\n"..string.rep("=", #idea.name).."]";
-	form = form .. doc.widgets.text(idea.description, doc.FORMSPEC.ENTRY_START_X, doc.FORMSPEC.ENTRY_START_Y + 1,
-			doc.FORMSPEC.ENTRY_WIDTH - 0.4, desc_height-1)
+					
+	if is_visible then
+		form = form .. doc.widgets.text(idea.description, FORM.ENTRY_START_X, FORM.ENTRY_START_Y + 1,
+				FORM.ENTRY_WIDTH - 0.4, desc_height-1)
+	else
+		form = form .. "label["
+					..FORM.ENTRY_START_X..","..(FORM.ENTRY_START_Y+2)
+					..";This idea is not yet discovered by your team.]";
+	end
 
 	local function form_render_tech_entry(rn, what, label, xstart, img, cnt)
 		form = form .. "image_button["
-						..(doc.FORMSPEC.ENTRY_START_X+xstart)..","..(tech_start_y + rn*tech_line_h - 0.2)..";1,1;"
+						..(FORM.ENTRY_START_X+xstart)..","..(tech_start_y + rn*tech_line_h - 0.2)..";1,1;"
 						..img..";"
 						.."goto_"..what.."_"..rn..";"
 						.."]"
 		form = form .. "label["
-					..(doc.FORMSPEC.ENTRY_START_X+xstart+1)..","..(tech_start_y + rn*tech_line_h)
+					..(FORM.ENTRY_START_X+xstart+1)..","..(tech_start_y + rn*tech_line_h)
 					..";"..label.."]";
 		if cnt then
 			form = form .. "label["
-					..(doc.FORMSPEC.ENTRY_START_X+xstart-0.5)..","..(tech_start_y + rn*tech_line_h)
+					..(FORM.ENTRY_START_X+xstart-0.5)..","..(tech_start_y + rn*tech_line_h)
 					..";"..cnt.."x]";
 		end
 	end
 
 	form = form .. "label["
-					..(doc.FORMSPEC.ENTRY_START_X)..","..(tech_start_y+0.2)
+					..(FORM.ENTRY_START_X)..","..(tech_start_y+0.2)
 					..";Technologies gained:]";
 	for rn, techid in ipairs(idea.technologies_gained) do
 		local tech = ctw_technologies.get_technology(techid)
 		form_render_tech_entry(rn, "tg", tech.name, 0, "ctw_technologies_technology.png")
 	end
 	form = form .. "label["
-					..(doc.FORMSPEC.ENTRY_START_X+third_width)..","..(tech_start_y+0.2)
+					..(FORM.ENTRY_START_X+third_width)..","..(tech_start_y+0.2)
 					..";Technologies required:]";
 	for rn, techid in ipairs(idea.technologies_required) do
 		local tech = ctw_technologies.get_technology(techid)
-		form_render_tech_entry(rn, "tr", tech.name, third_width, "ctw_technologies_technology.png")
+		local tname = tech.name
+		local gained = ctw_technologies.is_tech_gained(techid,team)
+		if not gained then
+			tname = minetest.colorize("#FF0000", tech.name)
+		end
+		form_render_tech_entry(rn, "tr", tname, third_width, "ctw_technologies_technology.png")
 	end
 	form = form .. "label["
-					..(doc.FORMSPEC.ENTRY_START_X+2*third_width)..","..(tech_start_y+0.2)
+					..(FORM.ENTRY_START_X+2*third_width)..","..(tech_start_y+0.2)
 					..";References required:]";
 	for rn, ref in ipairs(idea.references_required) do
 		local istack = ItemStack(ref)
@@ -87,57 +134,46 @@ local function idea_form_builder(id)
 		form_render_tech_entry(rn, "rr", iname, 2*third_width, itex, istack:get_count())
 	end
 
-	return form
+	-- show it
+	minetest.show_formspec(pname, "ctw_resources:idea_"..id, form)
+	return true
 end
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	local pname = player:get_player_name()
-	if formname == "doc:entry" then
-		local cid, eid = doc.get_selection(pname)
-		if cid == "ctw_ideas" then
-			local idea = ideas[eid]
-			if not idea then
-				return
+	
+	local id = string.match(formname, "^ctw_resources:idea_(.+)$");
+	if id then
+		local idea = ideas[id]
+		if not idea then
+			return
+		end
+		for rn, techid in ipairs(idea.technologies_gained) do
+			if fields["goto_tg_"..rn] then
+				ctw_technologies.show_technology_form(pname, techid)
 			end
-			for rn, techid in ipairs(idea.technologies_gained) do
-				if fields["goto_tg_"..rn] then
-					if doc.entry_exists("ctw_technologies", techid) and doc.entry_revealed(pname, "ctw_technologies", techid) then
-						doc.show_entry(pname, "ctw_technologies", techid)
-					end
-				end
+		end
+		for rn, techid in ipairs(idea.technologies_required) do
+			if fields["goto_tr_"..rn] then
+				ctw_technologies.show_technology_form(pname, techid)
 			end
-			for rn, techid in ipairs(idea.technologies_required) do
-				if fields["goto_tr_"..rn] then
-					if doc.entry_exists("ctw_technologies", techid) and doc.entry_revealed(pname, "ctw_technologies", techid) then
-						doc.show_entry(pname, "ctw_technologies", techid)
-					end
-				end
-			end
-			for rn, ref in ipairs(idea.references_required) do
-				if fields["goto_rr_"..rn] then
-					local istack = ItemStack(ref)
-					local iid = istack:get_name()
-					if iid and doc.entry_exists("ctw_references", iid) then
-						doc.show_entry(pname, "ctw_references", iid)
-					end
-				end
+		end
+		for rn, ref in ipairs(idea.references_required) do
+			if fields["goto_rr_"..rn] then
+				local istack = ItemStack(ref)
+				local iid = istack:get_name()
+				ctw_resources.show_reference_form(pname, iid)
 			end
 		end
 	end
 
 end)
 
-doc.add_category("ctw_ideas", {
-	name = "Ideas",
-	description = "Ideas that your team gained",
-	build_formspec = idea_form_builder
-})
-
 local function idea_info(itemstack, player, pointed_thing)
 	local pname = player:get_player_name()
 	local idef = minetest.registered_items[itemstack:get_name()]
 	if idef._ctw_idea_id then
-		doc.show_entry(pname, "ctw_ideas", idef._ctw_idea_id)
+		ctw_resources.show_idea_form(pname, idef._ctw_idea_id)
 	end
 end
 
@@ -165,12 +201,6 @@ function ctw_resources.register_idea(id, idea_def, itemdef_p)
 		end
 	end
 	idea_def.technologies_required = techreq
-
-	doc.add_entry("ctw_ideas", id, {
-		name = idea_def.name,
-		data = id,
-		hidden = true,
-	})
 
 	-- register idea item
 	local itemdef = itemdef_p or { inventory_image = "ctw_resources_idea_generic.png" }
@@ -314,25 +344,4 @@ function ctw_resources.set_team_idea_state(idea_id, team, state, param)
 	end
 	team._ctw_resources_idea_state[idea_id] = istate
 
-	ctw_resources.update_doc_reveals(team)
 end
-
-function ctw_resources.update_doc_reveals(team)
-	for idea_id, idea in pairs(ideas) do
-		local istate = ctw_resources.get_team_idea_state(idea_id, team)
-		for _,player in ipairs(teams.get_online_members(team.name)) do
-			if istate.state ~= "undiscovered" then
-				if istate.state ~= "discovered" or player:get_player_name() == istate.by then
-					doc.mark_entry_as_revealed(player:get_player_name(), "ctw_ideas", idea_id)
-				end
-			end
-		end
-	end
-end
-
-minetest.register_on_joinplayer(function(player)
-	local team = teams.get_by_player(player:get_player_name())
-	if team then
-		ctw_resources.update_doc_reveals(team)
-	end
-end)

--- a/mods/ctw_resources/ideas.lua
+++ b/mods/ctw_resources/ideas.lua
@@ -288,7 +288,7 @@ function ctw_resources.give_idea(idea_id, pname, inventory, invlist, try)
 	minetest.chat_send_player(pname, "You got an idea: "..idea.name..
 			"! Proceed to your team space and share it on the team billboard!")
 	inventory:add_item(invlist, "ctw_resources:idea_"..idea_id)
-	doc.mark_entry_as_revealed(pname, "ctw_ideas", idea_id)
+	
 	-- Note: if another player secretly had gotten this idea before, this will be overwritten.
 	-- Should not cause side-effects.
 	ctw_resources.set_team_idea_state(idea_id, team, "discovered", pname)

--- a/mods/ctw_resources/references.lua
+++ b/mods/ctw_resources/references.lua
@@ -65,6 +65,7 @@ function ctw_resources.show_reference_form(pname, id)
 	
 	-- show it
 	minetest.show_formspec(pname, "ctw_resources:ref_"..id, form)
+	return true
 end
 
 function ctw_resources.register_reference(id, itemdef)

--- a/mods/ctw_resources/references.lua
+++ b/mods/ctw_resources/references.lua
@@ -52,12 +52,29 @@ function ctw_resources.show_reference_form(pname, id)
 		title = ref.name,
 		text = ref.description,
 		
-	})
+	}, pname)
 	
 	-- show it
 	minetest.show_formspec(pname, "ctw_resources:ref_"..id, form)
 	return true
 end
+
+minetest.register_on_player_receive_fields(function(player, formname, fields)
+	local pname = player:get_player_name()
+	
+	local id = string.match(formname, "^ctw_resources:ref_(.+)$");
+	if id then
+		if fields.goto_back then
+			ctw_technologies.form_returnstack_pop(pname)
+		end
+		
+		if fields.quit then
+			ctw_technologies.form_returnstack_clear(pname)
+		end
+		
+	end
+
+end)
 
 function ctw_resources.register_reference(id, itemdef)
 	if not itemdef.groups then

--- a/mods/ctw_resources/references.lua
+++ b/mods/ctw_resources/references.lua
@@ -28,20 +28,6 @@ end
 
 local reference_entries = {}
 
--- Formspec information
-FORM = {}
--- Width of formspec
-FORM.WIDTH = 15
-FORM.HEIGHT = 10.5
-
---[[ Recommended bounding box coordinates for widgets to be placed in entry pages. Make sure
-all entry widgets are completely inside these coordinates to avoid overlapping. ]]
-FORM.ENTRY_START_X = 1
-FORM.ENTRY_START_Y = 0.5
-FORM.ENTRY_END_X = FORM.WIDTH
-FORM.ENTRY_END_Y = FORM.HEIGHT - 0.5
-FORM.ENTRY_WIDTH = FORM.ENTRY_END_X - FORM.ENTRY_START_X
-FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
 
 function ctw_resources.show_reference_form(pname, id)
 	local ref = reference_entries[id]
@@ -49,19 +35,24 @@ function ctw_resources.show_reference_form(pname, id)
 		return false
 	end
 	
-	local form = "size["..FORM.WIDTH..","..FORM.HEIGHT.."]real_coordinates[]"
-	
-	form = form .. "vertlabel[0.15,0.5"
-					..";R E F E R E N C E]";
-	form = form .. "box[0,0;0.5,"..FORM.HEIGHT..";#00FF00]";
-	
-	
-	form = form .. "label["
-					..FORM.ENTRY_START_X..","..FORM.ENTRY_START_Y
-					..";"..ref.name.."\n"..string.rep("=", #ref.name).."]";
-	
-	form = form .. doc.widgets.text(ref.description, FORM.ENTRY_START_X, FORM.ENTRY_START_Y + 1,
-				FORM.ENTRY_WIDTH - 0.4, FORM.ENTRY_HEIGHT-1)
+	local form = ctw_technologies.get_detail_formspec({
+		bt1 = {
+			catlabel = "",
+			entries = {},
+		},
+		bt2 = {
+			catlabel = "",
+			entries = {},
+		},
+		bt3 = {
+			catlabel = "",
+			entries = {},
+		},
+		vert_text = "R E F E R E N C E",
+		title = ref.name,
+		text = ref.description,
+		
+	})
 	
 	-- show it
 	minetest.show_formspec(pname, "ctw_resources:ref_"..id, form)

--- a/mods/ctw_resources/references.lua
+++ b/mods/ctw_resources/references.lua
@@ -22,15 +22,50 @@ local function ref_info(itemstack, player, pointed_thing)
 	local pname = player:get_player_name()
 	local idef = minetest.registered_items[itemstack:get_name()]
 	if idef._ctw_reference_id then
-		doc.show_entry(pname, "ctw_references", idef._ctw_reference_id)
+		ctw_resources.show_reference_form(pname, idef._ctw_reference_id)
 	end
 end
 
-doc.add_category("ctw_references", {
-	name = "References",
-	description = "References you can collect",
-	build_formspec = doc.entry_builders.text,
-})
+local reference_entries = {}
+
+-- Formspec information
+FORM = {}
+-- Width of formspec
+FORM.WIDTH = 15
+FORM.HEIGHT = 10.5
+
+--[[ Recommended bounding box coordinates for widgets to be placed in entry pages. Make sure
+all entry widgets are completely inside these coordinates to avoid overlapping. ]]
+FORM.ENTRY_START_X = 1
+FORM.ENTRY_START_Y = 0.5
+FORM.ENTRY_END_X = FORM.WIDTH
+FORM.ENTRY_END_Y = FORM.HEIGHT - 0.5
+FORM.ENTRY_WIDTH = FORM.ENTRY_END_X - FORM.ENTRY_START_X
+FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
+
+function ctw_resources.show_reference_form(pname, id)
+	local ref = reference_entries[id]
+	if not ref then
+		return false
+	end
+	
+	local form = "size["..FORM.WIDTH..","..FORM.HEIGHT.."]real_coordinates[]"
+	
+	form = form .. "vertlabel[0.15,0.5"
+					..";R E F E R E N C E]";
+	form = form .. "box[0,0;0.5,"..FORM.HEIGHT..";#00FF00]";
+	
+	
+	form = form .. "label["
+					..FORM.ENTRY_START_X..","..FORM.ENTRY_START_Y
+					..";"..ref.name.."\n"..string.rep("=", #ref.name).."]";
+	
+	form = form .. doc.widgets.text(ref.description, FORM.ENTRY_START_X, FORM.ENTRY_START_Y + 1,
+				FORM.ENTRY_WIDTH - 0.4, FORM.ENTRY_HEIGHT-1)
+	
+	-- show it
+	minetest.show_formspec(pname, "ctw_resources:ref_"..id, form)
+end
 
 function ctw_resources.register_reference(id, itemdef)
 	if not itemdef.groups then
@@ -41,10 +76,10 @@ function ctw_resources.register_reference(id, itemdef)
 	itemdef.on_use = ref_info
 	itemdef._usage_hint = "Left-click to show information"
 
-	doc.add_entry("ctw_references", id, {
+	reference_entries[id] = {
 		name = itemdef.description,
-		data = "\n"..itemdef.description.."\n"..string.rep("=", #itemdef.description).."\n\n"..itemdef._ctw_longdesc,
-	})
+		description = itemdef._ctw_longdesc
+	}
 
 	minetest.register_craftitem(id, itemdef)
 end

--- a/mods/ctw_technologies/detail_form.lua
+++ b/mods/ctw_technologies/detail_form.lua
@@ -1,0 +1,107 @@
+-- Common template for the technology/idea/resource information formspec.
+-- Helps with links and backlinks
+	
+-- Formspec information
+FORM = {}
+-- Width of formspec
+FORM.WIDTH = 15
+FORM.HEIGHT = 10.5
+
+--[[ Recommended bounding box coordinates for widgets to be placed in entry pages. Make sure
+all entry widgets are completely inside these coordinates to avoid overlapping. ]]
+FORM.ENTRY_START_X = 1
+FORM.ENTRY_START_Y = 0.5
+FORM.ENTRY_END_X = FORM.WIDTH
+FORM.ENTRY_END_Y = FORM.HEIGHT - 0.5
+FORM.ENTRY_WIDTH = FORM.ENTRY_END_X - FORM.ENTRY_START_X
+FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
+	
+--[[ formdef = {
+	bt1 = {
+		catlabel = "Technologies required:",
+		func = function(entry, idx)-> btnname,label,img
+		entries
+	},
+	bt2 = ...,
+	bt3 = ...,
+	vert_text = "T E X T",
+	title = "World Wide Web",
+	text = "bla bla", --( if nil, uses a label with labeltext )
+	labeltext = "Undiscovered Technology",
+	
+	add_btn_name = "my_button", -- optional, additional extra button
+	add_btn_label = "My Extra Button",
+	
+} ]]--
+
+
+function ctw_technologies.get_detail_formspec(formdef)
+	local n_tech_lines = math.max(math.max(#formdef.bt1.entries, #formdef.bt2.entries), #formdef.bt3.entries)
+
+	local tech_line_h = 1
+	local desc_height = FORM.ENTRY_HEIGHT - tech_line_h*n_tech_lines - 0.5
+	local tech_start_y = FORM.ENTRY_START_Y + desc_height
+	local third_width = FORM.ENTRY_WIDTH / 3
+
+	local form = "size["..FORM.WIDTH..","..FORM.HEIGHT.."]real_coordinates[]"
+	
+	form = form .. "vertlabel[0.15,0.5"
+					..";"..formdef.vert_text.."]";
+	form = form .. "box[0,0;0.5,"..FORM.HEIGHT..";#00FF00]";
+	
+	
+	form = form .. "label["
+					..FORM.ENTRY_START_X..","..FORM.ENTRY_START_Y
+					..";"..formdef.title.."\n"..string.rep("=", #formdef.title).."]";
+	
+	if formdef.text then
+		form = form .. doc.widgets.text(formdef.text, FORM.ENTRY_START_X, FORM.ENTRY_START_Y + 1,
+				FORM.ENTRY_WIDTH - 0.4, desc_height-1)
+	else
+		form = form .. "label["
+					..FORM.ENTRY_START_X..","..(FORM.ENTRY_START_Y+2)
+					..";"..formdef.labeltext.."]";
+	end
+
+	local function form_render_tech_entry(idx, btnname, label, xstart, img)
+		form = form .. "image_button["
+						..(FORM.ENTRY_START_X+xstart)..","..(tech_start_y + idx*tech_line_h - 0.2)..";1,1;"
+						..img..";"
+						..btnname..";"
+						.."]"
+		form = form .. "label["
+					..(FORM.ENTRY_START_X+xstart+1)..","..(tech_start_y + idx*tech_line_h)
+					..";"..label.."]";
+	end
+
+	form = form .. "label["
+					..(FORM.ENTRY_START_X)..","..(tech_start_y+0.2)
+					..";"..formdef.bt1.catlabel.."]";
+	for idx,entry in ipairs(formdef.bt1.entries) do
+		local btnname,label,img = formdef.bt1.func(entry, idx)
+		form_render_tech_entry(idx, btnname, label, 0, img)
+	end
+	form = form .. "label["
+					..(FORM.ENTRY_START_X+third_width)..","..(tech_start_y+0.2)
+					..";"..formdef.bt2.catlabel.."]";
+	for idx,entry in ipairs(formdef.bt2.entries) do
+		local btnname,label,img = formdef.bt2.func(entry, idx)
+		form_render_tech_entry(idx, btnname, label, third_width, img)
+	end
+	form = form .. "label["
+					..(FORM.ENTRY_START_X+2*third_width)..","..(tech_start_y+0.2)
+					..";"..formdef.bt3.catlabel.."]";
+	for idx,entry in ipairs(formdef.bt3.entries) do
+		local btnname,label,img = formdef.bt3.func(entry, idx)
+		form_render_tech_entry(idx, btnname, label, 2*third_width, img)
+	end
+	
+	if formdef.add_btn_name then
+		form = form .. "button["
+				..(FORM.ENTRY_END_X-4.5)..","..(FORM.ENTRY_START_Y)..";4,1;"
+				..formdef.add_btn_name..";"
+				..formdef.add_btn_label.."]"
+	end
+
+	return form
+end

--- a/mods/ctw_technologies/detail_form.lua
+++ b/mods/ctw_technologies/detail_form.lua
@@ -33,12 +33,37 @@ FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
 	add_btn_label = "My Extra Button",
 	
 } ]]--
+local tech_line_h = 1
+
+local function form_render_tech_entries(form, xstart, tech_start_y, bt)
+	if not bt then return end
+	form = form .. "label["
+					..(FORM.ENTRY_START_X+xstart)..","..(tech_start_y+0.2)
+					..";"..bt.catlabel.."]";
+	for idx,entry in ipairs(bt.entries) do
+		local btnname,label,img = bt.func(entry, idx)
+		local itembtn = bt.use_item_image_button and "item_" or ""
+
+		form = form .. itembtn.."image_button["
+						..(FORM.ENTRY_START_X+xstart)..","..(tech_start_y + idx*tech_line_h - 0.2)..";1,1;"
+						..img..";"
+						..btnname..";"
+						.."]"
+		form = form .. "label["
+					..(FORM.ENTRY_START_X+xstart+1)..","..(tech_start_y + idx*tech_line_h)
+					..";"..label.."]";
+	end
+	return form
+end
 
 
 function ctw_technologies.get_detail_formspec(formdef)
-	local n_tech_lines = math.max(math.max(#formdef.bt1.entries, #formdef.bt2.entries), #formdef.bt3.entries)
+	local n_tech_lines = 0
+	if formdef.bt1 then n_tech_lines = math.max(n_tech_lines, #formdef.bt1.entries) end
+	if formdef.bt2 then n_tech_lines = math.max(n_tech_lines, #formdef.bt2.entries) end
+	if formdef.bt3 then n_tech_lines = math.max(n_tech_lines, #formdef.bt3.entries) end
+	
 
-	local tech_line_h = 1
 	local desc_height = FORM.ENTRY_HEIGHT - tech_line_h*n_tech_lines - 0.5
 	local tech_start_y = FORM.ENTRY_START_Y + desc_height
 	local third_width = FORM.ENTRY_WIDTH / 3
@@ -63,38 +88,11 @@ function ctw_technologies.get_detail_formspec(formdef)
 					..";"..formdef.labeltext.."]";
 	end
 
-	local function form_render_tech_entry(idx, btnname, label, xstart, img)
-		form = form .. "image_button["
-						..(FORM.ENTRY_START_X+xstart)..","..(tech_start_y + idx*tech_line_h - 0.2)..";1,1;"
-						..img..";"
-						..btnname..";"
-						.."]"
-		form = form .. "label["
-					..(FORM.ENTRY_START_X+xstart+1)..","..(tech_start_y + idx*tech_line_h)
-					..";"..label.."]";
-	end
 
-	form = form .. "label["
-					..(FORM.ENTRY_START_X)..","..(tech_start_y+0.2)
-					..";"..formdef.bt1.catlabel.."]";
-	for idx,entry in ipairs(formdef.bt1.entries) do
-		local btnname,label,img = formdef.bt1.func(entry, idx)
-		form_render_tech_entry(idx, btnname, label, 0, img)
-	end
-	form = form .. "label["
-					..(FORM.ENTRY_START_X+third_width)..","..(tech_start_y+0.2)
-					..";"..formdef.bt2.catlabel.."]";
-	for idx,entry in ipairs(formdef.bt2.entries) do
-		local btnname,label,img = formdef.bt2.func(entry, idx)
-		form_render_tech_entry(idx, btnname, label, third_width, img)
-	end
-	form = form .. "label["
-					..(FORM.ENTRY_START_X+2*third_width)..","..(tech_start_y+0.2)
-					..";"..formdef.bt3.catlabel.."]";
-	for idx,entry in ipairs(formdef.bt3.entries) do
-		local btnname,label,img = formdef.bt3.func(entry, idx)
-		form_render_tech_entry(idx, btnname, label, 2*third_width, img)
-	end
+	form = form_render_tech_entries(form, 0, tech_start_y, formdef.bt1)
+	form = form_render_tech_entries(form, third_width, tech_start_y, formdef.bt2)
+	form = form_render_tech_entries(form, 2*third_width, tech_start_y, formdef.bt3)
+	
 	
 	if formdef.add_btn_name then
 		form = form .. "button["

--- a/mods/ctw_technologies/init.lua
+++ b/mods/ctw_technologies/init.lua
@@ -8,6 +8,7 @@ local mp = minetest.get_modpath(minetest.get_current_modname()) .. DIR_DELIM
 dofile(mp.."technologies.lua")
 dofile(mp.."benefits.lua")
 dofile(mp.."tree.lua")
+dofile(mp.."detail_form.lua")
 dofile(mp.."benefit_defs.lua")
 dofile(mp.."tech_defs.lua")
 dofile(mp.."delivery.lua")

--- a/mods/ctw_technologies/technologies.lua
+++ b/mods/ctw_technologies/technologies.lua
@@ -56,22 +56,15 @@ function ctw_technologies.show_technology_form(pname, techid)
 		is_gained = true
 	end
 	
-	local function techfunc(tech_id)
-		local tech = ctw_technologies.get_technology(tech_id)
-		return "goto_tech_"..tech_id,
-				tech.name,
-				"ctw_technologies_technology.png"
-	end
-	
 	local form = ctw_technologies.get_detail_formspec({
 		bt1 = {
 			catlabel = "Technologies required:",
-			func = techfunc,
+			func = ctw_technologies.detail_formspec_bt_techfunc,
 			entries = tech.requires,
 		},
 		bt2 = {
 			catlabel = "Technologies unlocked:",
-			func = techfunc,
+			func = ctw_technologies.detail_formspec_bt_techfunc,
 			entries = tech.enables,
 		},
 		bt3 = {
@@ -90,13 +83,20 @@ function ctw_technologies.show_technology_form(pname, techid)
 		labeltext = "This technology is not yet discovered by your team.",
 		
 		add_btn_name = "tech_tree", -- optional, additional extra button
-		add_btn_label = "<<< Technology tree",
+		add_btn_label = "Technology tree",
 	})
 
 	-- show it
 	minetest.show_formspec(pname, "ctw_technologies:technology_"..techid, form)
 	return true
 end
+
+function ctw_technologies.detail_formspec_bt_techfunc(tech_id)
+		local tech = ctw_technologies.get_technology(tech_id)
+		return "goto_tech_"..tech_id,
+				tech.name,
+				"ctw_technologies_technology.png"
+	end
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	local pname = player:get_player_name()

--- a/mods/ctw_technologies/technologies.lua
+++ b/mods/ctw_technologies/technologies.lua
@@ -137,8 +137,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		end
 		for rn, techid in ipairs(tech.requires) do
 			if fields["goto_tr_"..rn] then
-				if doc.entry_exists("ctw_technologies", techid) and doc.entry_revealed(pname, "ctw_technologies", techid) then
-					doc.show_entry(pname, "ctw_technologies", techid)
+				if technologies[techid] then
+					ctw_technologies.show_technology_form(pname, techid)
 				end
 			end
 		end

--- a/mods/ctw_technologies/technologies.lua
+++ b/mods/ctw_technologies/technologies.lua
@@ -84,7 +84,7 @@ function ctw_technologies.show_technology_form(pname, techid)
 		
 		add_btn_name = "tech_tree", -- optional, additional extra button
 		add_btn_label = "Technology tree",
-	})
+	}, pname)
 
 	-- show it
 	minetest.show_formspec(pname, "ctw_technologies:technology_"..techid, form)
@@ -111,6 +111,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		for field,_ in pairs(fields) do
 			local tech_id = string.match(field, "^goto_tech_(.+)$");
 			if technologies[tech_id] then
+				ctw_technologies.form_returnstack_push(pname, function(pname) ctw_technologies.show_technology_form(pname, techid) end)
 				ctw_technologies.show_technology_form(pname, tech_id)
 				return
 			end
@@ -121,7 +122,16 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 			end
 		end
 		if fields.tech_tree then
+			ctw_technologies.form_returnstack_push(pname, function(pname) ctw_technologies.show_technology_form(pname, techid) end)
 			ctw_technologies.show_tech_tree(pname, 0)
+		end
+		
+		if fields.goto_back then
+			ctw_technologies.form_returnstack_pop(pname)
+		end
+		
+		if fields.quit then
+			ctw_technologies.form_returnstack_clear(pname)
 		end
 	end
 

--- a/mods/ctw_technologies/technologies.lua
+++ b/mods/ctw_technologies/technologies.lua
@@ -47,7 +47,7 @@ FORM.ENTRY_HEIGHT = FORM.ENTRY_END_Y - FORM.ENTRY_START_Y
 function ctw_technologies.show_technology_form(pname, techid)
 	local tech = technologies[techid]
 	if not tech then
-		error("tech_form_builder: ID "..techid.." is unknown!")
+		return false
 	end
 	
 	local team = teams.get_by_player(pname)
@@ -123,6 +123,7 @@ function ctw_technologies.show_technology_form(pname, techid)
 
 	-- show it
 	minetest.show_formspec(pname, "ctw_technologies:entry_"..techid, form)
+	return true
 end
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)

--- a/mods/ctw_technologies/tree.lua
+++ b/mods/ctw_technologies/tree.lua
@@ -273,9 +273,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		for techid, tech in pairs(technologies) do
 			-- look if field was clicked
 			if fields["goto_tech_"..techid] or fields["goto_techt_"..techid] then
-				if doc.entry_exists("ctw_technologies", techid) and doc.entry_revealed(pname, "ctw_technologies", techid) then
-					doc.show_entry(pname, "ctw_technologies", techid)
-				end
+				if ctw_technologies.get_technology_raw(techid) then
+						ctw_technologies.show_technology_form(pname, techid)
+					end
 				return
 			end
 			if fields.mleft then

--- a/mods/team_billboard/init.lua
+++ b/mods/team_billboard/init.lua
@@ -63,7 +63,7 @@ function team_billboard.show_billboard_form(pname, tname, pers_msg)
 	if pers_msg then
 		table.insert(form, "label[0,2;"..pers_msg.."]")
 	end
-	table.insert(form, "button[6.5,0;3.5,1;doc;View knowledge base]")
+	table.insert(form, "button[6.5,0;3.5,1;tech_tree;View Technology tree]")
 
 	for index, item in ipairs(ilist) do
 		if minetest.get_item_group(item:get_name(), "ctw_idea") > 0 then
@@ -111,9 +111,9 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		open_forms[tname][pname] = nil
 		return
 	end
-	if fields.doc then
+	if fields.tech_tree then
 		open_forms[tname][pname] = nil
-		doc.show_doc(pname)
+		ctw_technologies.show_tech_tree(pname,0)
 		return
 	end
 

--- a/mods/team_billboard/init.lua
+++ b/mods/team_billboard/init.lua
@@ -113,6 +113,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 	if fields.tech_tree then
 		open_forms[tname][pname] = nil
+		ctw_technologies.form_returnstack_push(pname, function(pname) team_billboard.show_billboard_form(pname, tname) end)
 		ctw_technologies.show_tech_tree(pname,0)
 		return
 	end
@@ -120,6 +121,8 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	for field, _ in pairs(fields) do
 		local idea_id = string.match(field, "^idea_(.+)$")
 		if idea_id then
+			open_forms[tname][pname] = nil
+			ctw_technologies.form_returnstack_push(pname, function(pname) team_billboard.show_billboard_form(pname, tname) end)
 			ctw_resources.show_idea_form(pname, idea_id)
 		end
 	end

--- a/mods/team_billboard/init.lua
+++ b/mods/team_billboard/init.lua
@@ -120,10 +120,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	for field, _ in pairs(fields) do
 		local idea_id = string.match(field, "^idea_(.+)$")
 		if idea_id then
-			if doc.entry_exists("ctw_ideas", idea_id) then
-				doc.show_entry(pname, "ctw_ideas", idea_id)
-				return
-			end
+			ctw_resources.show_idea_form(pname, idea_id)
 		end
 	end
 


### PR DESCRIPTION
I quickly changed the mentioned formspecs to no longer be doc pages. This gives us more flexibility in using them and eliminates the need to sync the "revealed" state of pages with the game mechanics. Also the new system features a "back" button to return to previous pages.

Note that the mods still depend on doc because they are still using the doc.widgets.text widget to display the text.

I now consider this complete.